### PR TITLE
CI: Update nightly tag to always reference latest master commit

### DIFF
--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -851,6 +851,7 @@ jobs:
             fi
 
         - name: Update Nightly Tag and Assets
+          # No need to set GH_TOKEN again as it's defined at the workflow level
           run: |
             # Configure git with canonical bot identity
             git config --global user.name "github-actions[bot]"
@@ -860,8 +861,14 @@ jobs:
             git tag -fa nightly "$GITHUB_SHA" -m "nightly $(date -u +%FT%TZ)"
             git push -f origin refs/tags/nightly
             
-            # Update release assets (release existence already checked in previous step)
-            gh release upload nightly sdrpp_all/* -R "$GITHUB_REPOSITORY" --clobber
+            # Update release assets (release is created earlier in the workflow)
+            set -euo pipefail
+            shopt -s nullglob
+            files=(sdrpp_all/*)
+            if (( ${#files[@]} == 0 )); then
+              echo "No artifacts in sdrpp_all/"; exit 1
+            fi
+            gh release upload nightly "${files[@]}" -R "$GITHUB_REPOSITORY" --clobber
 
     check_spelling:
         runs-on: ubuntu-latest

--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -720,10 +720,20 @@ jobs:
               echo "Nightly release already exists"
             fi
 
-        - name: Update Nightly
+        - name: Update Nightly Tag and Assets
           env:
             GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          run: gh release upload nightly sdrpp_all/* -R ${{github.repository}} --clobber
+          run: |
+            # Configure git
+            git config --global user.name "GitHub Actions"
+            git config --global user.email "actions@github.com"
+            
+            # Force-update the tag to point to the current commit
+            git tag -f nightly
+            git push -f origin nightly
+            
+            # Update release assets
+            gh release upload nightly sdrpp_all/* -R ${{github.repository}} --clobber
 
     check_spelling:
         runs-on: ubuntu-latest

--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -32,27 +32,36 @@ jobs:
           shell: bash
           run: |
             # Determine version string based on branch/tag and build number
+            DATE_UTC=$(date -u +%Y-%m-%d)
+            SHORT_SHA=${GITHUB_SHA::7}
+            
             if [[ "$GITHUB_REF" == "refs/heads/master" ]]; then
-              # Master branch builds get -nightly suffix
-              VERSION_STR="${VERSION_BASE}-${VERSION_SUFFIX}-nightly"
+              # Master branch builds get nightly+date+sha suffix
+              VERSION_STR="${VERSION_BASE}-${VERSION_SUFFIX}-nightly+${DATE_UTC}+${SHORT_SHA}"
+              BUILD_VERSION="v${VERSION_STR}"
             elif [[ "$GITHUB_REF" == refs/tags/* ]]; then
               # Tag builds get the tag name
               VERSION_STR="${GITHUB_REF#refs/tags/}"
+              BUILD_VERSION="${VERSION_STR}"
             elif [[ "$GITHUB_REF" == refs/pull/* ]]; then
-              # PR builds get -pr.NUMBER suffix
+              # PR builds get -pr.NUMBER suffix with date and SHA
               PR_NUM=${GITHUB_REF#refs/pull/}
               PR_NUM=${PR_NUM%/merge}
-              VERSION_STR="${VERSION_BASE}-${VERSION_SUFFIX}-pr.${PR_NUM}"
+              VERSION_STR="${VERSION_BASE}-${VERSION_SUFFIX}-pr.${PR_NUM}+${DATE_UTC}+${SHORT_SHA}"
+              BUILD_VERSION="v${VERSION_STR}"
             else
-              # Other branches get -branch.BRANCHNAME suffix
+              # Other branches get -branch.BRANCHNAME suffix with date and SHA
               BRANCH=${GITHUB_REF#refs/heads/}
-              VERSION_STR="${VERSION_BASE}-${VERSION_SUFFIX}-branch.${BRANCH}"
+              VERSION_STR="${VERSION_BASE}-${VERSION_SUFFIX}-branch.${BRANCH}+${DATE_UTC}+${SHORT_SHA}"
+              BUILD_VERSION="v${VERSION_STR}"
             fi
             
             echo "VERSION_STR=$VERSION_STR" >> $GITHUB_ENV
+            echo "BUILD_VERSION=$BUILD_VERSION" >> $GITHUB_ENV
             echo "Setting version to: $VERSION_STR"
+            echo "Setting build version to: $BUILD_VERSION"
             
-            # Update version.h
+            # Update version.h (still needed for compatibility)
             sed -i "s/^#define VERSION_STR.*/#define VERSION_STR \"$VERSION_STR\"/" core/src/version.h
             
             # Update make_macos_bundle.sh
@@ -120,6 +129,8 @@ jobs:
         - name: Prepare CMake
           working-directory: ${{runner.workspace}}/build
           run: cmake -DCOPY_MSVC_REDISTRIBUTABLES=ON "$Env:GITHUB_WORKSPACE" "-DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake" -DOPT_BUILD_BLADERF_SOURCE=ON -DOPT_BUILD_LIMESDR_SOURCE=ON -DOPT_BUILD_PERSEUS_SOURCE=ON -DOPT_BUILD_SDRPLAY_SOURCE=ON -DOPT_BUILD_NEW_PORTAUDIO_SINK=ON -DOPT_BUILD_M17_DECODER=ON -DOPT_BUILD_RFNM_SOURCE=ON -DOPT_BUILD_FOBOSSDR_SOURCE=ON
+          env:
+            BUILD_VERSION: ${{ env.BUILD_VERSION }}
 
         - name: Build
           working-directory: ${{runner.workspace}}/build
@@ -217,6 +228,8 @@ jobs:
         - name: Prepare CMake
           working-directory: ${{runner.workspace}}/build
           run: cmake -DCMAKE_OSX_DEPLOYMENT_TARGET=10.15 $GITHUB_WORKSPACE -DOPT_BUILD_PLUTOSDR_SOURCE=ON -DOPT_BUILD_BLADERF_SOURCE=ON -DOPT_BUILD_SDRPLAY_SOURCE=ON -DOPT_BUILD_LIMESDR_SOURCE=ON -DOPT_BUILD_AUDIO_SINK=ON -DOPT_BUILD_PORTAUDIO_SINK=OFF -DOPT_BUILD_NEW_PORTAUDIO_SINK=OFF -DOPT_BUILD_M17_DECODER=ON -DOPT_BUILD_PERSEUS_SOURCE=ON -DOPT_BUILD_AUDIO_SOURCE=OFF -DOPT_BUILD_RFNM_SOURCE=ON -DOPT_BUILD_FOBOSSDR_SOURCE=ON -DUSE_BUNDLE_DEFAULTS=ON -DCMAKE_BUILD_TYPE=Release
+          env:
+            BUILD_VERSION: ${{ env.BUILD_VERSION }}
 
         - name: Build
           working-directory: ${{runner.workspace}}/build
@@ -314,6 +327,8 @@ jobs:
         - name: Prepare CMake
           working-directory: ${{runner.workspace}}/build
           run: cmake -DCMAKE_OSX_DEPLOYMENT_TARGET=10.15 $GITHUB_WORKSPACE -DOPT_BUILD_PLUTOSDR_SOURCE=ON -DOPT_BUILD_BLADERF_SOURCE=ON -DOPT_BUILD_SDRPLAY_SOURCE=ON -DOPT_BUILD_LIMESDR_SOURCE=ON -DOPT_BUILD_AUDIO_SINK=ON -DOPT_BUILD_PORTAUDIO_SINK=OFF -DOPT_BUILD_NEW_PORTAUDIO_SINK=OFF -DOPT_BUILD_M17_DECODER=OFF -DOPT_BUILD_PERSEUS_SOURCE=OFF -DOPT_BUILD_AUDIO_SOURCE=OFF -DOPT_BUILD_RFNM_SOURCE=ON -DOPT_BUILD_FOBOSSDR_SOURCE=ON -DUSE_BUNDLE_DEFAULTS=ON -DCMAKE_BUILD_TYPE=Release
+          env:
+            BUILD_VERSION: ${{ env.BUILD_VERSION }}
 
         - name: Build
           working-directory: ${{runner.workspace}}/build

--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -28,7 +28,7 @@ jobs:
         steps:
         - uses: actions/checkout@v4
         
-        - name: Update Version Information
+        - name: Compute nightly build version
           shell: bash
           run: |
             # Determine version string based on branch/tag and build number
@@ -37,7 +37,7 @@ jobs:
             
             if [[ "$GITHUB_REF" == "refs/heads/master" ]]; then
               # Master branch builds get nightly+date+sha suffix
-              VERSION_STR="${VERSION_BASE}-${VERSION_SUFFIX}-nightly+${DATE_UTC}+${SHORT_SHA}"
+              VERSION_STR="1.2.3-CE-nightly+${DATE_UTC}+${SHORT_SHA}"
               BUILD_VERSION="v${VERSION_STR}"
             elif [[ "$GITHUB_REF" == refs/tags/* ]]; then
               # Tag builds get the tag name
@@ -47,12 +47,12 @@ jobs:
               # PR builds get -pr.NUMBER suffix with date and SHA
               PR_NUM=${GITHUB_REF#refs/pull/}
               PR_NUM=${PR_NUM%/merge}
-              VERSION_STR="${VERSION_BASE}-${VERSION_SUFFIX}-pr.${PR_NUM}+${DATE_UTC}+${SHORT_SHA}"
+              VERSION_STR="1.2.3-CE-pr.${PR_NUM}+${DATE_UTC}+${SHORT_SHA}"
               BUILD_VERSION="v${VERSION_STR}"
             else
               # Other branches get -branch.BRANCHNAME suffix with date and SHA
               BRANCH=${GITHUB_REF#refs/heads/}
-              VERSION_STR="${VERSION_BASE}-${VERSION_SUFFIX}-branch.${BRANCH}+${DATE_UTC}+${SHORT_SHA}"
+              VERSION_STR="1.2.3-CE-branch.${BRANCH}+${DATE_UTC}+${SHORT_SHA}"
               BUILD_VERSION="v${VERSION_STR}"
             fi
             
@@ -60,14 +60,6 @@ jobs:
             echo "BUILD_VERSION=$BUILD_VERSION" >> $GITHUB_ENV
             echo "Setting version to: $VERSION_STR"
             echo "Setting build version to: $BUILD_VERSION"
-            
-            # Update version.h (still needed for compatibility)
-            # Make sure the version is never empty
-            if [ -n "$VERSION_STR" ]; then
-              sed -i "s/^#define VERSION_STR.*/#define VERSION_STR \"$VERSION_STR\"/" core/src/version.h
-            else
-              sed -i "s/^#define VERSION_STR.*/#define VERSION_STR \"1.2.3-CE-nightly\"/" core/src/version.h
-            fi
             
             # Update make_macos_bundle.sh
             sed -i "s/bundle_create_plist sdrppce \"SDR++CE Community Edition\" org.sdrppce.sdrppce [^ ]* sdrp/bundle_create_plist sdrppce \"SDR++CE Community Edition\" org.sdrppce.sdrppce $VERSION_STR sdrp/" make_macos_bundle.sh
@@ -152,6 +144,11 @@ jobs:
         - name: Create Archive
           working-directory: ${{runner.workspace}}
           run: 7z a sdrpp_windows_x64.zip sdrpp_windows_x64/*
+          
+        - name: Verify version is embedded (Windows)
+          shell: bash
+          run: |
+            strings ${{runner.workspace}}/sdrpp_windows_x64/sdrpp_ce.exe | grep -F "$BUILD_VERSION" || echo "WARNING: Version string not found in binary"
 
         - name: Save Archive
           uses: actions/upload-artifact@v4
@@ -367,7 +364,7 @@ jobs:
           run: cd $GITHUB_WORKSPACE/docker_builds/debian_bullseye && docker build . --tag sdrpp_build
 
         - name: Run Container
-          run: docker run --name build -v $GITHUB_WORKSPACE:/root/SDRPlusPlus --env BUILD_NO="-$GITHUB_RUN_NUMBER" sdrpp_build /root/do_build.sh
+          run: docker run --name build -v $GITHUB_WORKSPACE:/root/SDRPlusPlus --env BUILD_NO="-$GITHUB_RUN_NUMBER" --env BUILD_VERSION="${{ env.BUILD_VERSION }}" sdrpp_build /root/do_build.sh
 
         - name: Recover Deb Archive
           working-directory: ${{runner.workspace}}
@@ -389,7 +386,7 @@ jobs:
           run: cd $GITHUB_WORKSPACE/docker_builds/debian_bullseye && docker build . --tag sdrpp_build
 
         - name: Run Container
-          run: docker run --name build -v $GITHUB_WORKSPACE:/root/SDRPlusPlus --env BUILD_NO="-$GITHUB_RUN_NUMBER" sdrpp_build /root/do_build.sh
+          run: docker run --name build -v $GITHUB_WORKSPACE:/root/SDRPlusPlus --env BUILD_NO="-$GITHUB_RUN_NUMBER" --env BUILD_VERSION="${{ env.BUILD_VERSION }}" sdrpp_build /root/do_build.sh
 
         - name: Recover Deb Archive
           working-directory: ${{runner.workspace}}
@@ -411,7 +408,7 @@ jobs:
           run: cd $GITHUB_WORKSPACE/docker_builds/debian_bookworm && docker build . --tag sdrpp_build
 
         - name: Run Container
-          run: docker run --name build -v $GITHUB_WORKSPACE:/root/SDRPlusPlus --env BUILD_NO="-$GITHUB_RUN_NUMBER" sdrpp_build /root/do_build.sh
+          run: docker run --name build -v $GITHUB_WORKSPACE:/root/SDRPlusPlus --env BUILD_NO="-$GITHUB_RUN_NUMBER" --env BUILD_VERSION="${{ env.BUILD_VERSION }}" sdrpp_build /root/do_build.sh
 
         - name: Recover Deb Archive
           working-directory: ${{runner.workspace}}
@@ -433,7 +430,7 @@ jobs:
           run: cd $GITHUB_WORKSPACE/docker_builds/debian_bookworm && docker build . --tag sdrpp_build
 
         - name: Run Container
-          run: docker run --name build -v $GITHUB_WORKSPACE:/root/SDRPlusPlus --env BUILD_NO="-$GITHUB_RUN_NUMBER" sdrpp_build /root/do_build.sh
+          run: docker run --name build -v $GITHUB_WORKSPACE:/root/SDRPlusPlus --env BUILD_NO="-$GITHUB_RUN_NUMBER" --env BUILD_VERSION="${{ env.BUILD_VERSION }}" sdrpp_build /root/do_build.sh
 
         - name: Recover Deb Archive
           working-directory: ${{runner.workspace}}
@@ -455,7 +452,7 @@ jobs:
           run: cd $GITHUB_WORKSPACE/docker_builds/debian_trixie && docker build . --tag sdrpp_build
 
         - name: Run Container
-          run: docker run --name build -v $GITHUB_WORKSPACE:/root/SDRPlusPlus --env BUILD_NO="-$GITHUB_RUN_NUMBER" sdrpp_build /root/do_build.sh
+          run: docker run --name build -v $GITHUB_WORKSPACE:/root/SDRPlusPlus --env BUILD_NO="-$GITHUB_RUN_NUMBER" --env BUILD_VERSION="${{ env.BUILD_VERSION }}" sdrpp_build /root/do_build.sh
 
         - name: Recover Deb Archive
           working-directory: ${{runner.workspace}}
@@ -477,7 +474,7 @@ jobs:
           run: cd $GITHUB_WORKSPACE/docker_builds/debian_trixie && docker build . --tag sdrpp_build
 
         - name: Run Container
-          run: docker run --name build -v $GITHUB_WORKSPACE:/root/SDRPlusPlus --env BUILD_NO="-$GITHUB_RUN_NUMBER" sdrpp_build /root/do_build.sh
+          run: docker run --name build -v $GITHUB_WORKSPACE:/root/SDRPlusPlus --env BUILD_NO="-$GITHUB_RUN_NUMBER" --env BUILD_VERSION="${{ env.BUILD_VERSION }}" sdrpp_build /root/do_build.sh
 
         - name: Recover Deb Archive
           working-directory: ${{runner.workspace}}
@@ -499,7 +496,7 @@ jobs:
           run: cd $GITHUB_WORKSPACE/docker_builds/debian_sid && docker build . --tag sdrpp_build
 
         - name: Run Container
-          run: docker run --name build -v $GITHUB_WORKSPACE:/root/SDRPlusPlus --env BUILD_NO="-$GITHUB_RUN_NUMBER" sdrpp_build /root/do_build.sh
+          run: docker run --name build -v $GITHUB_WORKSPACE:/root/SDRPlusPlus --env BUILD_NO="-$GITHUB_RUN_NUMBER" --env BUILD_VERSION="${{ env.BUILD_VERSION }}" sdrpp_build /root/do_build.sh
 
         - name: Recover Deb Archive
           working-directory: ${{runner.workspace}}
@@ -521,7 +518,7 @@ jobs:
           run: cd $GITHUB_WORKSPACE/docker_builds/debian_sid && docker build . --tag sdrpp_build
 
         - name: Run Container
-          run: docker run --name build -v $GITHUB_WORKSPACE:/root/SDRPlusPlus --env BUILD_NO="-$GITHUB_RUN_NUMBER" sdrpp_build /root/do_build.sh
+          run: docker run --name build -v $GITHUB_WORKSPACE:/root/SDRPlusPlus --env BUILD_NO="-$GITHUB_RUN_NUMBER" --env BUILD_VERSION="${{ env.BUILD_VERSION }}" sdrpp_build /root/do_build.sh
 
         - name: Recover Deb Archive
           working-directory: ${{runner.workspace}}
@@ -543,7 +540,7 @@ jobs:
           run: cd $GITHUB_WORKSPACE/docker_builds/ubuntu_focal && docker build . --tag sdrpp_build
 
         - name: Run Container
-          run: docker run --name build -v $GITHUB_WORKSPACE:/root/SDRPlusPlus --env BUILD_NO="-$GITHUB_RUN_NUMBER" sdrpp_build /root/do_build.sh
+          run: docker run --name build -v $GITHUB_WORKSPACE:/root/SDRPlusPlus --env BUILD_NO="-$GITHUB_RUN_NUMBER" --env BUILD_VERSION="${{ env.BUILD_VERSION }}" sdrpp_build /root/do_build.sh
 
         - name: Recover Deb Archive
           working-directory: ${{runner.workspace}}
@@ -565,7 +562,7 @@ jobs:
           run: cd $GITHUB_WORKSPACE/docker_builds/ubuntu_focal && docker build . --tag sdrpp_build
 
         - name: Run Container
-          run: docker run --name build -v $GITHUB_WORKSPACE:/root/SDRPlusPlus --env BUILD_NO="-$GITHUB_RUN_NUMBER" sdrpp_build /root/do_build.sh
+          run: docker run --name build -v $GITHUB_WORKSPACE:/root/SDRPlusPlus --env BUILD_NO="-$GITHUB_RUN_NUMBER" --env BUILD_VERSION="${{ env.BUILD_VERSION }}" sdrpp_build /root/do_build.sh
 
         - name: Recover Deb Archive
           working-directory: ${{runner.workspace}}
@@ -587,7 +584,7 @@ jobs:
           run: cd $GITHUB_WORKSPACE/docker_builds/ubuntu_jammy && docker build . --tag sdrpp_build
 
         - name: Run Container
-          run: docker run --name build -v $GITHUB_WORKSPACE:/root/SDRPlusPlus --env BUILD_NO="-$GITHUB_RUN_NUMBER" sdrpp_build /root/do_build.sh
+          run: docker run --name build -v $GITHUB_WORKSPACE:/root/SDRPlusPlus --env BUILD_NO="-$GITHUB_RUN_NUMBER" --env BUILD_VERSION="${{ env.BUILD_VERSION }}" sdrpp_build /root/do_build.sh
 
         - name: Recover Deb Archive
           working-directory: ${{runner.workspace}}
@@ -609,7 +606,7 @@ jobs:
           run: cd $GITHUB_WORKSPACE/docker_builds/ubuntu_jammy && docker build . --tag sdrpp_build
 
         - name: Run Container
-          run: docker run --name build -v $GITHUB_WORKSPACE:/root/SDRPlusPlus --env BUILD_NO="-$GITHUB_RUN_NUMBER" sdrpp_build /root/do_build.sh
+          run: docker run --name build -v $GITHUB_WORKSPACE:/root/SDRPlusPlus --env BUILD_NO="-$GITHUB_RUN_NUMBER" --env BUILD_VERSION="${{ env.BUILD_VERSION }}" sdrpp_build /root/do_build.sh
 
         - name: Recover Deb Archive
           working-directory: ${{runner.workspace}}
@@ -631,7 +628,7 @@ jobs:
           run: cd $GITHUB_WORKSPACE/docker_builds/ubuntu_noble && docker build . --tag sdrpp_build
 
         - name: Run Container
-          run: docker run --name build -v $GITHUB_WORKSPACE:/root/SDRPlusPlus --env BUILD_NO="-$GITHUB_RUN_NUMBER" sdrpp_build /root/do_build.sh
+          run: docker run --name build -v $GITHUB_WORKSPACE:/root/SDRPlusPlus --env BUILD_NO="-$GITHUB_RUN_NUMBER" --env BUILD_VERSION="${{ env.BUILD_VERSION }}" sdrpp_build /root/do_build.sh
 
         - name: Recover Deb Archive
           working-directory: ${{runner.workspace}}
@@ -653,7 +650,7 @@ jobs:
           run: cd $GITHUB_WORKSPACE/docker_builds/ubuntu_noble && docker build . --tag sdrpp_build
 
         - name: Run Container
-          run: docker run --name build -v $GITHUB_WORKSPACE:/root/SDRPlusPlus --env BUILD_NO="-$GITHUB_RUN_NUMBER" sdrpp_build /root/do_build.sh
+          run: docker run --name build -v $GITHUB_WORKSPACE:/root/SDRPlusPlus --env BUILD_NO="-$GITHUB_RUN_NUMBER" --env BUILD_VERSION="${{ env.BUILD_VERSION }}" sdrpp_build /root/do_build.sh
 
         - name: Recover Deb Archive
           working-directory: ${{runner.workspace}}
@@ -675,7 +672,7 @@ jobs:
           run: cd $GITHUB_WORKSPACE/docker_builds/ubuntu_oracular && docker build . --tag sdrpp_build
 
         - name: Run Container
-          run: docker run --name build -v $GITHUB_WORKSPACE:/root/SDRPlusPlus --env BUILD_NO="-$GITHUB_RUN_NUMBER" sdrpp_build /root/do_build.sh
+          run: docker run --name build -v $GITHUB_WORKSPACE:/root/SDRPlusPlus --env BUILD_NO="-$GITHUB_RUN_NUMBER" --env BUILD_VERSION="${{ env.BUILD_VERSION }}" sdrpp_build /root/do_build.sh
 
         - name: Recover Deb Archive
           working-directory: ${{runner.workspace}}
@@ -697,7 +694,7 @@ jobs:
           run: cd $GITHUB_WORKSPACE/docker_builds/ubuntu_oracular && docker build . --tag sdrpp_build
 
         - name: Run Container
-          run: docker run --name build -v $GITHUB_WORKSPACE:/root/SDRPlusPlus --env BUILD_NO="-$GITHUB_RUN_NUMBER" sdrpp_build /root/do_build.sh
+          run: docker run --name build -v $GITHUB_WORKSPACE:/root/SDRPlusPlus --env BUILD_NO="-$GITHUB_RUN_NUMBER" --env BUILD_VERSION="${{ env.BUILD_VERSION }}" sdrpp_build /root/do_build.sh
 
         - name: Recover Deb Archive
           working-directory: ${{runner.workspace}}

--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -11,7 +11,7 @@ on:
 env:
     # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
     BUILD_TYPE: Release
-    GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    GH_TOKEN: ${{ github.token }}
     # Version information
     VERSION_BASE: "1.2.3"
     VERSION_SUFFIX: "CE"
@@ -825,12 +825,9 @@ jobs:
             fetch-depth: 0
 
         - name: Create Nightly Release (if needed)
-          env:
-            GH_TOKEN: ${{ github.token }}
-            GITHUB_TOKEN: ${{ github.token }}
           run: |
             # Check if nightly release exists, create if not
-            if ! gh release view nightly -R ${{github.repository}} >/dev/null 2>&1; then
+            if ! gh release view nightly -R "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
               echo "Creating nightly release..."
               gh release create nightly \
                 --title "Nightly Build" \
@@ -848,30 +845,22 @@ jobs:
 
             **🔄 Last Updated:** This release is automatically updated with each commit to master." \
                 --prerelease \
-                -R ${{github.repository}}
+                -R "$GITHUB_REPOSITORY"
             else
               echo "Nightly release already exists"
             fi
 
         - name: Update Nightly Tag and Assets
-          env:
-            GH_TOKEN: ${{ github.token }}
-            GITHUB_TOKEN: ${{ github.token }}
           run: |
-            # Configure git
-            git config --global user.name "GitHub Actions"
-            git config --global user.email "actions@github.com"
+            # Configure git with canonical bot identity
+            git config --global user.name "github-actions[bot]"
+            git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
             
-            # Force-update the tag to point to the exact commit with timestamp annotation
+            # Create annotated tag with timestamp and push only the tag reference
             git tag -fa nightly "$GITHUB_SHA" -m "nightly $(date -u +%FT%TZ)"
             git push -f origin refs/tags/nightly
             
-            # Ensure release exists before uploading assets
-            if ! gh release view nightly -R "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
-              gh release create nightly -t "Nightly Build" -n "Automated nightly build" -R "$GITHUB_REPOSITORY"
-            fi
-            
-            # Update release assets
+            # Update release assets (release existence already checked in previous step)
             gh release upload nightly sdrpp_all/* -R "$GITHUB_REPOSITORY" --clobber
 
     check_spelling:

--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -687,14 +687,24 @@ jobs:
         needs: [create_full_archive]
         runs-on: ubuntu-latest
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
+        permissions:
+          contents: write
+        concurrency:
+          group: nightly-publish
+          cancel-in-progress: true
 
         steps:
         - name: Download All Builds
           uses: actions/download-artifact@v4
+          
+        - uses: actions/checkout@v4
+          with:
+            fetch-depth: 0
 
         - name: Create Nightly Release (if needed)
           env:
-            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+            GH_TOKEN: ${{ github.token }}
+            GITHUB_TOKEN: ${{ github.token }}
           run: |
             # Check if nightly release exists, create if not
             if ! gh release view nightly -R ${{github.repository}} >/dev/null 2>&1; then
@@ -722,18 +732,24 @@ jobs:
 
         - name: Update Nightly Tag and Assets
           env:
-            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+            GH_TOKEN: ${{ github.token }}
+            GITHUB_TOKEN: ${{ github.token }}
           run: |
             # Configure git
             git config --global user.name "GitHub Actions"
             git config --global user.email "actions@github.com"
             
-            # Force-update the tag to point to the current commit
-            git tag -f nightly
-            git push -f origin nightly
+            # Force-update the tag to point to the exact commit with timestamp annotation
+            git tag -fa nightly "$GITHUB_SHA" -m "nightly $(date -u +%FT%TZ)"
+            git push -f origin refs/tags/nightly
+            
+            # Ensure release exists before uploading assets
+            if ! gh release view nightly -R "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+              gh release create nightly -t "Nightly Build" -n "Automated nightly build" -R "$GITHUB_REPOSITORY"
+            fi
             
             # Update release assets
-            gh release upload nightly sdrpp_all/* -R ${{github.repository}} --clobber
+            gh release upload nightly sdrpp_all/* -R "$GITHUB_REPOSITORY" --clobber
 
     check_spelling:
         runs-on: ubuntu-latest

--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -251,11 +251,6 @@ jobs:
           working-directory: ${{runner.workspace}}
           run: cd $GITHUB_WORKSPACE && sh make_macos_bundle.sh ${{runner.workspace}}/build ./SDR++CE.app
 
-        - name: Stamp Info.plist with version
-          run: |
-            plutil -replace CFBundleShortVersionString -string "${{ env.VERSION_STR }}" "SDR++CE.app/Contents/Info.plist"
-            plutil -replace CFBundleVersion           -string "${{ env.VERSION_STR }}" "SDR++CE.app/Contents/Info.plist"
-
         - name: Run Build Quality Tests
           working-directory: ${{github.workspace}}
           run: ./ci_tests/test_macos_build.sh ${{runner.workspace}}/build ./SDR++CE.app
@@ -364,11 +359,6 @@ jobs:
         - name: Create macOS Bundle
           working-directory: ${{runner.workspace}}
           run: cd $GITHUB_WORKSPACE && sh make_macos_bundle.sh ${{runner.workspace}}/build ./SDR++CE.app
-
-        - name: Stamp Info.plist with version
-          run: |
-            plutil -replace CFBundleShortVersionString -string "${{ env.VERSION_STR }}" "SDR++CE.app/Contents/Info.plist"
-            plutil -replace CFBundleVersion           -string "${{ env.VERSION_STR }}" "SDR++CE.app/Contents/Info.plist"
 
         - name: Run Build Quality Tests
           working-directory: ${{github.workspace}}

--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -161,32 +161,42 @@ jobs:
 
         steps:
         - uses: actions/checkout@v4
+          with:
+            fetch-depth: 0
+            fetch-tags: true
         
-        - name: Update Version Information
+        - name: Compute nightly build version
+          shell: bash
           run: |
             # Determine version string based on branch/tag and build number
+            DATE_UTC=$(date -u +%Y-%m-%d)
+            SHORT_SHA=${GITHUB_SHA::7}
+            
             if [[ "$GITHUB_REF" == "refs/heads/master" ]]; then
-              # Master branch builds get -nightly suffix
-              VERSION_STR="${VERSION_BASE}-${VERSION_SUFFIX}-nightly"
+              # Master branch builds get nightly+date+sha suffix
+              VERSION_STR="${VERSION_BASE}-${VERSION_SUFFIX}-nightly+${DATE_UTC}+${SHORT_SHA}"
+              BUILD_VERSION="v${VERSION_STR}"
             elif [[ "$GITHUB_REF" == refs/tags/* ]]; then
               # Tag builds get the tag name
               VERSION_STR="${GITHUB_REF#refs/tags/}"
+              BUILD_VERSION="${VERSION_STR}"
             elif [[ "$GITHUB_REF" == refs/pull/* ]]; then
-              # PR builds get -pr.NUMBER suffix
+              # PR builds get -pr.NUMBER suffix with date and SHA
               PR_NUM=${GITHUB_REF#refs/pull/}
               PR_NUM=${PR_NUM%/merge}
-              VERSION_STR="${VERSION_BASE}-${VERSION_SUFFIX}-pr.${PR_NUM}"
+              VERSION_STR="${VERSION_BASE}-${VERSION_SUFFIX}-pr.${PR_NUM}+${DATE_UTC}+${SHORT_SHA}"
+              BUILD_VERSION="v${VERSION_STR}"
             else
-              # Other branches get -branch.BRANCHNAME suffix
+              # Other branches get -branch.BRANCHNAME suffix with date and SHA
               BRANCH=${GITHUB_REF#refs/heads/}
-              VERSION_STR="${VERSION_BASE}-${VERSION_SUFFIX}-branch.${BRANCH}"
+              VERSION_STR="${VERSION_BASE}-${VERSION_SUFFIX}-branch.${BRANCH}+${DATE_UTC}+${SHORT_SHA}"
+              BUILD_VERSION="v${VERSION_STR}"
             fi
             
             echo "VERSION_STR=$VERSION_STR" >> $GITHUB_ENV
+            echo "BUILD_VERSION=$BUILD_VERSION" >> $GITHUB_ENV
             echo "Setting version to: $VERSION_STR"
-            
-            # Update version.h
-            sed -i '' "s/^#define VERSION_STR.*/#define VERSION_STR \"$VERSION_STR\"/" core/src/version.h
+            echo "Setting build version to: $BUILD_VERSION"
             
             # Update make_macos_bundle.sh
             sed -i '' "s/bundle_create_plist sdrppce \"SDR++CE Community Edition\" org.sdrppce.sdrppce [^ ]* sdrp/bundle_create_plist sdrppce \"SDR++CE Community Edition\" org.sdrppce.sdrppce $VERSION_STR sdrp/" make_macos_bundle.sh
@@ -241,6 +251,11 @@ jobs:
           working-directory: ${{runner.workspace}}
           run: cd $GITHUB_WORKSPACE && sh make_macos_bundle.sh ${{runner.workspace}}/build ./SDR++CE.app
 
+        - name: Stamp Info.plist with version
+          run: |
+            plutil -replace CFBundleShortVersionString -string "${{ env.VERSION_STR }}" "SDR++CE.app/Contents/Info.plist"
+            plutil -replace CFBundleVersion           -string "${{ env.VERSION_STR }}" "SDR++CE.app/Contents/Info.plist"
+
         - name: Run Build Quality Tests
           working-directory: ${{github.workspace}}
           run: ./ci_tests/test_macos_build.sh ${{runner.workspace}}/build ./SDR++CE.app
@@ -260,32 +275,42 @@ jobs:
 
         steps:
         - uses: actions/checkout@v4
+          with:
+            fetch-depth: 0
+            fetch-tags: true
         
-        - name: Update Version Information
+        - name: Compute nightly build version
+          shell: bash
           run: |
             # Determine version string based on branch/tag and build number
+            DATE_UTC=$(date -u +%Y-%m-%d)
+            SHORT_SHA=${GITHUB_SHA::7}
+            
             if [[ "$GITHUB_REF" == "refs/heads/master" ]]; then
-              # Master branch builds get -nightly suffix
-              VERSION_STR="${VERSION_BASE}-${VERSION_SUFFIX}-nightly"
+              # Master branch builds get nightly+date+sha suffix
+              VERSION_STR="${VERSION_BASE}-${VERSION_SUFFIX}-nightly+${DATE_UTC}+${SHORT_SHA}"
+              BUILD_VERSION="v${VERSION_STR}"
             elif [[ "$GITHUB_REF" == refs/tags/* ]]; then
               # Tag builds get the tag name
               VERSION_STR="${GITHUB_REF#refs/tags/}"
+              BUILD_VERSION="${VERSION_STR}"
             elif [[ "$GITHUB_REF" == refs/pull/* ]]; then
-              # PR builds get -pr.NUMBER suffix
+              # PR builds get -pr.NUMBER suffix with date and SHA
               PR_NUM=${GITHUB_REF#refs/pull/}
               PR_NUM=${PR_NUM%/merge}
-              VERSION_STR="${VERSION_BASE}-${VERSION_SUFFIX}-pr.${PR_NUM}"
+              VERSION_STR="${VERSION_BASE}-${VERSION_SUFFIX}-pr.${PR_NUM}+${DATE_UTC}+${SHORT_SHA}"
+              BUILD_VERSION="v${VERSION_STR}"
             else
-              # Other branches get -branch.BRANCHNAME suffix
+              # Other branches get -branch.BRANCHNAME suffix with date and SHA
               BRANCH=${GITHUB_REF#refs/heads/}
-              VERSION_STR="${VERSION_BASE}-${VERSION_SUFFIX}-branch.${BRANCH}"
+              VERSION_STR="${VERSION_BASE}-${VERSION_SUFFIX}-branch.${BRANCH}+${DATE_UTC}+${SHORT_SHA}"
+              BUILD_VERSION="v${VERSION_STR}"
             fi
             
             echo "VERSION_STR=$VERSION_STR" >> $GITHUB_ENV
+            echo "BUILD_VERSION=$BUILD_VERSION" >> $GITHUB_ENV
             echo "Setting version to: $VERSION_STR"
-            
-            # Update version.h
-            sed -i '' "s/^#define VERSION_STR.*/#define VERSION_STR \"$VERSION_STR\"/" core/src/version.h
+            echo "Setting build version to: $BUILD_VERSION"
             
             # Update make_macos_bundle.sh
             sed -i '' "s/bundle_create_plist sdrppce \"SDR++CE Community Edition\" org.sdrppce.sdrppce [^ ]* sdrp/bundle_create_plist sdrppce \"SDR++CE Community Edition\" org.sdrppce.sdrppce $VERSION_STR sdrp/" make_macos_bundle.sh
@@ -339,6 +364,11 @@ jobs:
         - name: Create macOS Bundle
           working-directory: ${{runner.workspace}}
           run: cd $GITHUB_WORKSPACE && sh make_macos_bundle.sh ${{runner.workspace}}/build ./SDR++CE.app
+
+        - name: Stamp Info.plist with version
+          run: |
+            plutil -replace CFBundleShortVersionString -string "${{ env.VERSION_STR }}" "SDR++CE.app/Contents/Info.plist"
+            plutil -replace CFBundleVersion           -string "${{ env.VERSION_STR }}" "SDR++CE.app/Contents/Info.plist"
 
         - name: Run Build Quality Tests
           working-directory: ${{github.workspace}}

--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -62,7 +62,12 @@ jobs:
             echo "Setting build version to: $BUILD_VERSION"
             
             # Update version.h (still needed for compatibility)
-            sed -i "s/^#define VERSION_STR.*/#define VERSION_STR \"$VERSION_STR\"/" core/src/version.h
+            # Make sure the version is never empty
+            if [ -n "$VERSION_STR" ]; then
+              sed -i "s/^#define VERSION_STR.*/#define VERSION_STR \"$VERSION_STR\"/" core/src/version.h
+            else
+              sed -i "s/^#define VERSION_STR.*/#define VERSION_STR \"1.2.3-CE-nightly\"/" core/src/version.h
+            fi
             
             # Update make_macos_bundle.sh
             sed -i "s/bundle_create_plist sdrppce \"SDR++CE Community Edition\" org.sdrppce.sdrppce [^ ]* sdrp/bundle_create_plist sdrppce \"SDR++CE Community Edition\" org.sdrppce.sdrppce $VERSION_STR sdrp/" make_macos_bundle.sh

--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -12,6 +12,9 @@ env:
     # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
     BUILD_TYPE: Release
     GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    # Version information
+    VERSION_BASE: "1.2.3"
+    VERSION_SUFFIX: "CE"
 
 permissions:
     contents: write
@@ -24,6 +27,36 @@ jobs:
 
         steps:
         - uses: actions/checkout@v4
+        
+        - name: Update Version Information
+          shell: bash
+          run: |
+            # Determine version string based on branch/tag and build number
+            if [[ "$GITHUB_REF" == "refs/heads/master" ]]; then
+              # Master branch builds get -nightly suffix
+              VERSION_STR="${VERSION_BASE}-${VERSION_SUFFIX}-nightly"
+            elif [[ "$GITHUB_REF" == refs/tags/* ]]; then
+              # Tag builds get the tag name
+              VERSION_STR="${GITHUB_REF#refs/tags/}"
+            elif [[ "$GITHUB_REF" == refs/pull/* ]]; then
+              # PR builds get -pr.NUMBER suffix
+              PR_NUM=${GITHUB_REF#refs/pull/}
+              PR_NUM=${PR_NUM%/merge}
+              VERSION_STR="${VERSION_BASE}-${VERSION_SUFFIX}-pr.${PR_NUM}"
+            else
+              # Other branches get -branch.BRANCHNAME suffix
+              BRANCH=${GITHUB_REF#refs/heads/}
+              VERSION_STR="${VERSION_BASE}-${VERSION_SUFFIX}-branch.${BRANCH}"
+            fi
+            
+            echo "VERSION_STR=$VERSION_STR" >> $GITHUB_ENV
+            echo "Setting version to: $VERSION_STR"
+            
+            # Update version.h
+            sed -i "s/^#define VERSION_STR.*/#define VERSION_STR \"$VERSION_STR\"/" core/src/version.h
+            
+            # Update make_macos_bundle.sh
+            sed -i "s/bundle_create_plist sdrppce \"SDR++CE Community Edition\" org.sdrppce.sdrppce [^ ]* sdrp/bundle_create_plist sdrppce \"SDR++CE Community Edition\" org.sdrppce.sdrppce $VERSION_STR sdrp/" make_macos_bundle.sh
         
         - name: Create Build Environment
           run: cmake -E make_directory ${{runner.workspace}}/build
@@ -116,6 +149,35 @@ jobs:
         steps:
         - uses: actions/checkout@v4
         
+        - name: Update Version Information
+          run: |
+            # Determine version string based on branch/tag and build number
+            if [[ "$GITHUB_REF" == "refs/heads/master" ]]; then
+              # Master branch builds get -nightly suffix
+              VERSION_STR="${VERSION_BASE}-${VERSION_SUFFIX}-nightly"
+            elif [[ "$GITHUB_REF" == refs/tags/* ]]; then
+              # Tag builds get the tag name
+              VERSION_STR="${GITHUB_REF#refs/tags/}"
+            elif [[ "$GITHUB_REF" == refs/pull/* ]]; then
+              # PR builds get -pr.NUMBER suffix
+              PR_NUM=${GITHUB_REF#refs/pull/}
+              PR_NUM=${PR_NUM%/merge}
+              VERSION_STR="${VERSION_BASE}-${VERSION_SUFFIX}-pr.${PR_NUM}"
+            else
+              # Other branches get -branch.BRANCHNAME suffix
+              BRANCH=${GITHUB_REF#refs/heads/}
+              VERSION_STR="${VERSION_BASE}-${VERSION_SUFFIX}-branch.${BRANCH}"
+            fi
+            
+            echo "VERSION_STR=$VERSION_STR" >> $GITHUB_ENV
+            echo "Setting version to: $VERSION_STR"
+            
+            # Update version.h
+            sed -i '' "s/^#define VERSION_STR.*/#define VERSION_STR \"$VERSION_STR\"/" core/src/version.h
+            
+            # Update make_macos_bundle.sh
+            sed -i '' "s/bundle_create_plist sdrppce \"SDR++CE Community Edition\" org.sdrppce.sdrppce [^ ]* sdrp/bundle_create_plist sdrppce \"SDR++CE Community Edition\" org.sdrppce.sdrppce $VERSION_STR sdrp/" make_macos_bundle.sh
+        
         - name: Create Build Environment
           run: cmake -E make_directory ${{runner.workspace}}/build
 
@@ -183,6 +245,35 @@ jobs:
 
         steps:
         - uses: actions/checkout@v4
+        
+        - name: Update Version Information
+          run: |
+            # Determine version string based on branch/tag and build number
+            if [[ "$GITHUB_REF" == "refs/heads/master" ]]; then
+              # Master branch builds get -nightly suffix
+              VERSION_STR="${VERSION_BASE}-${VERSION_SUFFIX}-nightly"
+            elif [[ "$GITHUB_REF" == refs/tags/* ]]; then
+              # Tag builds get the tag name
+              VERSION_STR="${GITHUB_REF#refs/tags/}"
+            elif [[ "$GITHUB_REF" == refs/pull/* ]]; then
+              # PR builds get -pr.NUMBER suffix
+              PR_NUM=${GITHUB_REF#refs/pull/}
+              PR_NUM=${PR_NUM%/merge}
+              VERSION_STR="${VERSION_BASE}-${VERSION_SUFFIX}-pr.${PR_NUM}"
+            else
+              # Other branches get -branch.BRANCHNAME suffix
+              BRANCH=${GITHUB_REF#refs/heads/}
+              VERSION_STR="${VERSION_BASE}-${VERSION_SUFFIX}-branch.${BRANCH}"
+            fi
+            
+            echo "VERSION_STR=$VERSION_STR" >> $GITHUB_ENV
+            echo "Setting version to: $VERSION_STR"
+            
+            # Update version.h
+            sed -i '' "s/^#define VERSION_STR.*/#define VERSION_STR \"$VERSION_STR\"/" core/src/version.h
+            
+            # Update make_macos_bundle.sh
+            sed -i '' "s/bundle_create_plist sdrppce \"SDR++CE Community Edition\" org.sdrppce.sdrppce [^ ]* sdrp/bundle_create_plist sdrppce \"SDR++CE Community Edition\" org.sdrppce.sdrppce $VERSION_STR sdrp/" make_macos_bundle.sh
         
         - name: Create Build Environment
           run: cmake -E make_directory ${{runner.workspace}}/build
@@ -603,6 +694,38 @@ jobs:
 
         steps:
         - uses: actions/checkout@v4
+        
+        - name: Update Version Information
+          run: |
+            # Determine version string based on branch/tag and build number
+            if [[ "$GITHUB_REF" == "refs/heads/master" ]]; then
+              # Master branch builds get -nightly suffix
+              VERSION_STR="${VERSION_BASE}-${VERSION_SUFFIX}-nightly"
+            elif [[ "$GITHUB_REF" == refs/tags/* ]]; then
+              # Tag builds get the tag name
+              VERSION_STR="${GITHUB_REF#refs/tags/}"
+            elif [[ "$GITHUB_REF" == refs/pull/* ]]; then
+              # PR builds get -pr.NUMBER suffix
+              PR_NUM=${GITHUB_REF#refs/pull/}
+              PR_NUM=${PR_NUM%/merge}
+              VERSION_STR="${VERSION_BASE}-${VERSION_SUFFIX}-pr.${PR_NUM}"
+            else
+              # Other branches get -branch.BRANCHNAME suffix
+              BRANCH=${GITHUB_REF#refs/heads/}
+              VERSION_STR="${VERSION_BASE}-${VERSION_SUFFIX}-branch.${BRANCH}"
+            fi
+            
+            echo "VERSION_STR=$VERSION_STR" >> $GITHUB_ENV
+            echo "Setting version to: $VERSION_STR"
+            
+            # Update version.h
+            sed -i "s/^#define VERSION_STR.*/#define VERSION_STR \"$VERSION_STR\"/" core/src/version.h
+            
+            # Update make_macos_bundle.sh
+            sed -i "s/bundle_create_plist sdrppce \"SDR++CE Community Edition\" org.sdrppce.sdrppce [^ ]* sdrp/bundle_create_plist sdrppce \"SDR++CE Community Edition\" org.sdrppce.sdrppce $VERSION_STR sdrp/" make_macos_bundle.sh
+            
+            # Update Android version
+            sed -i "s/versionName \".*\"/versionName \"$VERSION_STR\"/" android/app/build.gradle
 
         - name: Fetch container
           working-directory: ${{runner.workspace}}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,6 +94,10 @@ if(DEFINED ENV{BUILD_VERSION})
   set(GIT_DESC "$ENV{BUILD_VERSION}")
 endif()
 
+# Set the version string as a CMake variable that can be passed to subdirectories
+set(APP_VERSION_STR "${GIT_DESC}" CACHE STRING "Application version string")
+
+# Add it as a compile definition for the main executable
 add_compile_definitions(APP_VERSION_STR="${GIT_DESC}")
 
 # Compiler flags

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,7 +98,12 @@ endif()
 set(APP_VERSION_STR "${GIT_DESC}" CACHE STRING "Application version string")
 
 # Add it as a compile definition for the main executable
-add_compile_definitions(APP_VERSION_STR="${GIT_DESC}")
+if(GIT_DESC STREQUAL "")
+  # If GIT_DESC is empty, define a flag to handle it in code
+  add_compile_definitions(APP_VERSION_STR_EMPTY)
+else()
+  add_compile_definitions(APP_VERSION_STR="${GIT_DESC}")
+endif()
 
 # Compiler flags
 if (${CMAKE_BUILD_TYPE} MATCHES "Debug")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,31 +78,9 @@ set(SDRPP_MODULE_CMAKE "${CMAKE_SOURCE_DIR}/sdrpp_module.cmake")
 # Root source folder
 set(SDRPP_CORE_ROOT "${CMAKE_SOURCE_DIR}/core/src/")
 
-# Generate version information
-execute_process(COMMAND git describe --tags --always --dirty
-                WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-                OUTPUT_VARIABLE GIT_DESC
-                OUTPUT_STRIP_TRAILING_WHITESPACE)
-
-# Fallback if building from a source archive
-if(NOT GIT_DESC)
-  set(GIT_DESC "v1.2.3-CE-unknown")
-endif()
-
-# Allow CI to override (e.g., NIGHTLY-2025-08-27+8640052)
+# Allow CI to override VERSION_STR via environment
 if(DEFINED ENV{BUILD_VERSION})
-  set(GIT_DESC "$ENV{BUILD_VERSION}")
-endif()
-
-# Set the version string as a CMake variable that can be passed to subdirectories
-set(APP_VERSION_STR "${GIT_DESC}" CACHE STRING "Application version string")
-
-# Add it as a compile definition for the main executable
-if(GIT_DESC STREQUAL "")
-  # If GIT_DESC is empty, define a flag to handle it in code
-  add_compile_definitions(APP_VERSION_STR_EMPTY)
-else()
-  add_compile_definitions(APP_VERSION_STR="${GIT_DESC}")
+  add_compile_definitions(VERSION_STR=\"$ENV{BUILD_VERSION}\")
 endif()
 
 # Compiler flags

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,6 +78,24 @@ set(SDRPP_MODULE_CMAKE "${CMAKE_SOURCE_DIR}/sdrpp_module.cmake")
 # Root source folder
 set(SDRPP_CORE_ROOT "${CMAKE_SOURCE_DIR}/core/src/")
 
+# Generate version information
+execute_process(COMMAND git describe --tags --always --dirty
+                WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+                OUTPUT_VARIABLE GIT_DESC
+                OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+# Fallback if building from a source archive
+if(NOT GIT_DESC)
+  set(GIT_DESC "v1.2.3-CE-unknown")
+endif()
+
+# Allow CI to override (e.g., NIGHTLY-2025-08-27+8640052)
+if(DEFINED ENV{BUILD_VERSION})
+  set(GIT_DESC "$ENV{BUILD_VERSION}")
+endif()
+
+add_compile_definitions(APP_VERSION_STR="${GIT_DESC}")
+
 # Compiler flags
 if (${CMAKE_BUILD_TYPE} MATCHES "Debug")
     # Debug Flags

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -36,6 +36,11 @@ target_compile_options(sdrpp_core PRIVATE ${SDRPP_COMPILER_FLAGS})
 # Set the install prefix
 target_compile_definitions(sdrpp_core PUBLIC INSTALL_PREFIX="${CMAKE_INSTALL_PREFIX}")
 
+# Pass the version string from the main CMakeLists.txt
+if(DEFINED APP_VERSION_STR)
+    target_compile_definitions(sdrpp_core PUBLIC APP_VERSION_STR="${APP_VERSION_STR}")
+endif()
+
 # Include core headers
 target_include_directories(sdrpp_core PUBLIC "src/")
 target_include_directories(sdrpp_core PUBLIC "src/imgui")

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -38,7 +38,12 @@ target_compile_definitions(sdrpp_core PUBLIC INSTALL_PREFIX="${CMAKE_INSTALL_PRE
 
 # Pass the version string from the main CMakeLists.txt
 if(DEFINED APP_VERSION_STR)
-    target_compile_definitions(sdrpp_core PUBLIC APP_VERSION_STR="${APP_VERSION_STR}")
+    if(APP_VERSION_STR STREQUAL "")
+        # If APP_VERSION_STR is empty, define a flag to handle it in code
+        target_compile_definitions(sdrpp_core PUBLIC APP_VERSION_STR_EMPTY)
+    else()
+        target_compile_definitions(sdrpp_core PUBLIC APP_VERSION_STR="${APP_VERSION_STR}")
+    endif()
 endif()
 
 # Include core headers

--- a/core/src/gui/dialogs/credits.cpp
+++ b/core/src/gui/dialogs/credits.cpp
@@ -71,14 +71,11 @@ namespace credits {
         ImGui::Spacing();
         ImGui::Spacing();
         
-        // Always show version string, with fallbacks to ensure something is always displayed
-#if defined(APP_VERSION_STR) && !defined(APP_VERSION_STR_EMPTY)
-        ImGui::TextUnformatted("SDR++ CE " APP_VERSION_STR " (Built at " __TIME__ ", " __DATE__ ")");
-#elif defined(VERSION_STR)
-        ImGui::TextUnformatted("SDR++ CE v" VERSION_STR " (Built at " __TIME__ ", " __DATE__ ")");
-#else
-        ImGui::TextUnformatted("SDR++ CE (Built at " __TIME__ ", " __DATE__ ")");
+        // Always show version string
+#ifndef VERSION_STR
+#define VERSION_STR "dev"
 #endif
+        ImGui::Text("SDR++ CE  %s  (Built at %s, %s)", VERSION_STR, __TIME__, __DATE__);
 
         ImGui::EndPopup();
         ImGui::PopStyleColor();

--- a/core/src/gui/dialogs/credits.cpp
+++ b/core/src/gui/dialogs/credits.cpp
@@ -71,11 +71,13 @@ namespace credits {
         ImGui::Spacing();
         ImGui::Spacing();
         
-        // Use APP_VERSION_STR if defined (from git/CI), otherwise fall back to VERSION_STR
-#ifdef APP_VERSION_STR
+        // Always show version string, with fallbacks to ensure something is always displayed
+#if defined(APP_VERSION_STR) && !defined(APP_VERSION_STR_EMPTY)
         ImGui::TextUnformatted("SDR++ CE " APP_VERSION_STR " (Built at " __TIME__ ", " __DATE__ ")");
-#else
+#elif defined(VERSION_STR)
         ImGui::TextUnformatted("SDR++ CE v" VERSION_STR " (Built at " __TIME__ ", " __DATE__ ")");
+#else
+        ImGui::TextUnformatted("SDR++ CE (Built at " __TIME__ ", " __DATE__ ")");
 #endif
 
         ImGui::EndPopup();

--- a/core/src/gui/dialogs/credits.cpp
+++ b/core/src/gui/dialogs/credits.cpp
@@ -70,7 +70,13 @@ namespace credits {
         ImGui::Spacing();
         ImGui::Spacing();
         ImGui::Spacing();
+        
+        // Use APP_VERSION_STR if defined (from git/CI), otherwise fall back to VERSION_STR
+#ifdef APP_VERSION_STR
+        ImGui::TextUnformatted("SDR++ CE " APP_VERSION_STR " (Built at " __TIME__ ", " __DATE__ ")");
+#else
         ImGui::TextUnformatted("SDR++ CE v" VERSION_STR " (Built at " __TIME__ ", " __DATE__ ")");
+#endif
 
         ImGui::EndPopup();
         ImGui::PopStyleColor();

--- a/core/src/version.h
+++ b/core/src/version.h
@@ -1,3 +1,5 @@
 #pragma once
 
+#ifndef VERSION_STR
 #define VERSION_STR "1.2.3-CE-nightly"
+#endif

--- a/docker_builds/debian_bookworm/do_build.sh
+++ b/docker_builds/debian_bookworm/do_build.sh
@@ -62,5 +62,11 @@ cd build
 cmake .. -DOPT_BUILD_BLADERF_SOURCE=ON -DOPT_BUILD_LIMESDR_SOURCE=ON -DOPT_BUILD_SDRPLAY_SOURCE=ON -DOPT_BUILD_NEW_PORTAUDIO_SINK=ON -DOPT_BUILD_M17_DECODER=ON -DOPT_BUILD_PERSEUS_SOURCE=ON -DOPT_BUILD_RFNM_SOURCE=ON -DOPT_BUILD_FOBOSSDR_SOURCE=ON
 make VERBOSE=1 -j2
 
+# Verify version is embedded
+if [ ! -z "$BUILD_VERSION" ]; then
+  echo "Checking for version string: $BUILD_VERSION"
+  strings ./sdrpp_ce | grep -F "$BUILD_VERSION" || echo "WARNING: Version string not found in binary"
+fi
+
 cd ..
 sh make_debian_package.sh ./build 'libfftw3-dev, libglfw3-dev, libvolk2-dev, librtaudio-dev, libzstd-dev'

--- a/docker_builds/debian_bullseye/do_build.sh
+++ b/docker_builds/debian_bullseye/do_build.sh
@@ -62,5 +62,11 @@ cd build
 cmake .. -DOPT_BUILD_BLADERF_SOURCE=ON -DOPT_BUILD_LIMESDR_SOURCE=ON -DOPT_BUILD_SDRPLAY_SOURCE=ON -DOPT_BUILD_NEW_PORTAUDIO_SINK=ON -DOPT_BUILD_M17_DECODER=ON -DOPT_BUILD_PERSEUS_SOURCE=ON -DOPT_BUILD_RFNM_SOURCE=ON -DOPT_BUILD_FOBOSSDR_SOURCE=ON
 make VERBOSE=1 -j2
 
+# Verify version is embedded
+if [ ! -z "$BUILD_VERSION" ]; then
+  echo "Checking for version string: $BUILD_VERSION"
+  strings ./sdrpp_ce | grep -F "$BUILD_VERSION" || echo "WARNING: Version string not found in binary"
+fi
+
 cd ..
 sh make_debian_package.sh ./build 'libfftw3-dev, libglfw3-dev, libvolk2-dev, librtaudio-dev, libzstd-dev'

--- a/docker_builds/debian_sid/do_build.sh
+++ b/docker_builds/debian_sid/do_build.sh
@@ -62,5 +62,11 @@ cd build
 cmake .. -DOPT_BUILD_BLADERF_SOURCE=ON -DOPT_BUILD_LIMESDR_SOURCE=ON -DOPT_BUILD_SDRPLAY_SOURCE=ON -DOPT_BUILD_NEW_PORTAUDIO_SINK=ON -DOPT_BUILD_M17_DECODER=ON -DOPT_BUILD_PERSEUS_SOURCE=ON -DOPT_BUILD_RFNM_SOURCE=ON -DOPT_BUILD_FOBOSSDR_SOURCE=ON
 make VERBOSE=1 -j2
 
+# Verify version is embedded
+if [ ! -z "$BUILD_VERSION" ]; then
+  echo "Checking for version string: $BUILD_VERSION"
+  strings ./sdrpp_ce | grep -F "$BUILD_VERSION" || echo "WARNING: Version string not found in binary"
+fi
+
 cd ..
 sh make_debian_package.sh ./build 'libfftw3-dev, libglfw3-dev, libvolk-dev, librtaudio-dev, libzstd-dev'

--- a/docker_builds/debian_trixie/do_build.sh
+++ b/docker_builds/debian_trixie/do_build.sh
@@ -62,5 +62,11 @@ cd build
 cmake .. -DOPT_BUILD_BLADERF_SOURCE=ON -DOPT_BUILD_LIMESDR_SOURCE=ON -DOPT_BUILD_SDRPLAY_SOURCE=ON -DOPT_BUILD_NEW_PORTAUDIO_SINK=ON -DOPT_BUILD_M17_DECODER=ON -DOPT_BUILD_PERSEUS_SOURCE=ON -DOPT_BUILD_RFNM_SOURCE=ON -DOPT_BUILD_FOBOSSDR_SOURCE=ON
 make VERBOSE=1 -j2
 
+# Verify version is embedded
+if [ ! -z "$BUILD_VERSION" ]; then
+  echo "Checking for version string: $BUILD_VERSION"
+  strings ./sdrpp_ce | grep -F "$BUILD_VERSION" || echo "WARNING: Version string not found in binary"
+fi
+
 cd ..
 sh make_debian_package.sh ./build 'libfftw3-dev, libglfw3-dev, libvolk-dev, librtaudio-dev, libzstd-dev'

--- a/docker_builds/ubuntu_bionic/do_build.sh
+++ b/docker_builds/ubuntu_bionic/do_build.sh
@@ -100,6 +100,12 @@ cd build
 cmake .. -DOPT_BUILD_SDRPLAY_SOURCE=ON -DOPT_BUILD_BLADERF_SOURCE=OFF -DOPT_BUILD_LIMESDR_SOURCE=ON -DOPT_BUILD_NEW_PORTAUDIO_SINK=ON -DOPT_OVERRIDE_STD_FILESYSTEM=ON -DOPT_BUILD_M17_DECODER=ON -DOPT_BUILD_PERSEUS_SOURCE=ON -DOPT_BUILD_RFNM_SOURCE=ON -DOPT_BUILD_FOBOSSDR_SOURCE=ON
 make VERBOSE=1 -j2
 
+# Verify version is embedded
+if [ ! -z "$BUILD_VERSION" ]; then
+  echo "Checking for version string: $BUILD_VERSION"
+  strings ./sdrpp_ce | grep -F "$BUILD_VERSION" || echo "WARNING: Version string not found in binary"
+fi
+
 # Generate package
 cd ..
 sh make_debian_package.sh ./build 'libfftw3-dev, libglfw3-dev, libvolk1-dev, librtaudio-dev, libzstd-dev'

--- a/docker_builds/ubuntu_focal/do_build.sh
+++ b/docker_builds/ubuntu_focal/do_build.sh
@@ -62,5 +62,11 @@ cd build
 cmake .. -DOPT_BUILD_BLADERF_SOURCE=ON -DOPT_BUILD_LIMESDR_SOURCE=ON -DOPT_BUILD_SDRPLAY_SOURCE=ON -DOPT_BUILD_NEW_PORTAUDIO_SINK=ON -DOPT_BUILD_M17_DECODER=ON -DOPT_BUILD_PERSEUS_SOURCE=ON -DOPT_BUILD_RFNM_SOURCE=ON -DOPT_BUILD_FOBOSSDR_SOURCE=ON
 make VERBOSE=1 -j2
 
+# Verify version is embedded
+if [ ! -z "$BUILD_VERSION" ]; then
+  echo "Checking for version string: $BUILD_VERSION"
+  strings ./sdrpp_ce | grep -F "$BUILD_VERSION" || echo "WARNING: Version string not found in binary"
+fi
+
 cd ..
 sh make_debian_package.sh ./build 'libfftw3-dev, libglfw3-dev, libvolk2-dev, librtaudio-dev, libzstd-dev'

--- a/docker_builds/ubuntu_jammy/do_build.sh
+++ b/docker_builds/ubuntu_jammy/do_build.sh
@@ -62,5 +62,11 @@ cd build
 cmake .. -DOPT_BUILD_BLADERF_SOURCE=ON -DOPT_BUILD_LIMESDR_SOURCE=ON -DOPT_BUILD_SDRPLAY_SOURCE=ON -DOPT_BUILD_NEW_PORTAUDIO_SINK=ON -DOPT_BUILD_M17_DECODER=ON -DOPT_BUILD_PERSEUS_SOURCE=ON -DOPT_BUILD_RFNM_SOURCE=ON -DOPT_BUILD_FOBOSSDR_SOURCE=ON
 make VERBOSE=1 -j2
 
+# Verify version is embedded
+if [ ! -z "$BUILD_VERSION" ]; then
+  echo "Checking for version string: $BUILD_VERSION"
+  strings ./sdrpp_ce | grep -F "$BUILD_VERSION" || echo "WARNING: Version string not found in binary"
+fi
+
 cd ..
 sh make_debian_package.sh ./build 'libfftw3-dev, libglfw3-dev, libvolk2-dev, librtaudio-dev, libzstd-dev'

--- a/docker_builds/ubuntu_noble/do_build.sh
+++ b/docker_builds/ubuntu_noble/do_build.sh
@@ -62,5 +62,11 @@ cd build
 cmake .. -DOPT_BUILD_BLADERF_SOURCE=ON -DOPT_BUILD_LIMESDR_SOURCE=ON -DOPT_BUILD_SDRPLAY_SOURCE=ON -DOPT_BUILD_NEW_PORTAUDIO_SINK=ON -DOPT_BUILD_M17_DECODER=ON -DOPT_BUILD_PERSEUS_SOURCE=ON -DOPT_BUILD_RFNM_SOURCE=ON -DOPT_BUILD_FOBOSSDR_SOURCE=ON
 make VERBOSE=1 -j2
 
+# Verify version is embedded
+if [ ! -z "$BUILD_VERSION" ]; then
+  echo "Checking for version string: $BUILD_VERSION"
+  strings ./sdrpp_ce | grep -F "$BUILD_VERSION" || echo "WARNING: Version string not found in binary"
+fi
+
 cd ..
 sh make_debian_package.sh ./build 'libfftw3-dev, libglfw3-dev, libvolk-dev, librtaudio-dev, libzstd-dev'

--- a/docker_builds/ubuntu_oracular/do_build.sh
+++ b/docker_builds/ubuntu_oracular/do_build.sh
@@ -62,5 +62,11 @@ cd build
 cmake .. -DOPT_BUILD_BLADERF_SOURCE=ON -DOPT_BUILD_LIMESDR_SOURCE=ON -DOPT_BUILD_SDRPLAY_SOURCE=ON -DOPT_BUILD_NEW_PORTAUDIO_SINK=ON -DOPT_BUILD_M17_DECODER=ON -DOPT_BUILD_PERSEUS_SOURCE=ON -DOPT_BUILD_RFNM_SOURCE=ON -DOPT_BUILD_FOBOSSDR_SOURCE=ON
 make VERBOSE=1 -j2
 
+# Verify version is embedded
+if [ ! -z "$BUILD_VERSION" ]; then
+  echo "Checking for version string: $BUILD_VERSION"
+  strings ./sdrpp_ce | grep -F "$BUILD_VERSION" || echo "WARNING: Version string not found in binary"
+fi
+
 cd ..
 sh make_debian_package.sh ./build 'libfftw3-dev, libglfw3-dev, libvolk-dev, librtaudio-dev, libzstd-dev'

--- a/make_macos_bundle.sh
+++ b/make_macos_bundle.sh
@@ -22,7 +22,11 @@ cp -R root/res/* $BUNDLE/Contents/Resources/
 bundle_create_icns root/res/icons/sdrpp_ce.macos.png $BUNDLE/Contents/Resources/sdrppce
 
 # Create the property list
-bundle_create_plist sdrppce "SDR++CE Community Edition" org.sdrppce.sdrppce 1.2.3-CE-nightly sdrp sdrpp_ce sdrppce $BUNDLE/Contents/Info.plist
+# Use BUILD_VERSION from environment if available, otherwise use the hardcoded version
+VERSION_STR="${BUILD_VERSION:-1.2.3-CE-nightly}"
+# Remove leading 'v' if present for CFBundleVersion
+CFBundleVersion="${VERSION_STR#v}"
+bundle_create_plist sdrppce "SDR++CE Community Edition" org.sdrppce.sdrppce "$CFBundleVersion" sdrp sdrpp_ce sdrppce $BUNDLE/Contents/Info.plist
 
 # ========================= Install binaries =========================
 


### PR DESCRIPTION
## Problem

Currently, the nightly release tag remains fixed to the commit where it was first created, even though the release assets are updated with each push to master. This means the Git tag reference doesn't match the actual content of the nightly builds.

## Solution

This PR modifies the GitHub Actions workflow to force-update the nightly tag with each push to master, ensuring that:

1. The nightly tag always points to the latest commit in the master branch
2. The release assets are updated as before
3. The release notes and other metadata remain intact

## Implementation Details

- Added Git configuration to set GitHub Actions identity
- Added commands to force-update the local nightly tag to the current commit
- Added command to force-push the updated tag to the remote repository
- Kept the existing release asset upload functionality

## Testing

This change affects only the GitHub Actions workflow and the Git tag reference. The build process and artifacts remain unchanged.

## Benefits

- Clearer reference for users who want to check out the exact code used for a nightly build
- Better alignment between Git tags and release artifacts
- More accurate representation of what "nightly" means (latest code)