### PR TITLE
scanner: Make accuracy independent of visual FFT

### DIFF
--- a/misc_modules/scanner/CMakeLists.txt
+++ b/misc_modules/scanner/CMakeLists.txt
@@ -9,7 +9,9 @@ file(GLOB SRC "src/*.cpp")
 
 include(${SDRPP_MODULE_CMAKE})
 
-target_include_directories(scanner PRIVATE "src/" "../../decoder_modules/radio/src")
+# We reuse the FFTW library that the core already links against
+target_include_directories(scanner PRIVATE "src/" "../../decoder_modules/radio/src" "../../" "../../core/src")
+target_link_libraries(scanner PRIVATE fftw3f)
 
 # Add debug logs define if enabled
 if(SCANNER_DEBUG_LOGS)

--- a/misc_modules/scanner/src/ScannerPSD.hpp
+++ b/misc_modules/scanner/src/ScannerPSD.hpp
@@ -1,0 +1,116 @@
+#pragma once
+
+#include <complex>
+#include <vector>
+#include <mutex>
+#include <memory>
+#include <atomic>
+#include <cstring>
+#include <cmath>
+
+// Include FFT implementation
+#include <fftw3.h>
+
+namespace scanner {
+
+// Window function types
+enum class WindowType {
+    RECTANGULAR,
+    BLACKMAN,
+    BLACKMAN_HARRIS_7,
+    HAMMING,
+    HANN
+};
+
+class ScannerPSD {
+public:
+    ScannerPSD() : m_fftwPlan(nullptr), m_fftwIn(nullptr), m_fftwOut(nullptr) {}
+    ~ScannerPSD();
+
+    // Initialize and configure the PSD engine
+    void init(int fftSize, int sampleRate, WindowType windowType = WindowType::BLACKMAN_HARRIS_7, 
+              float overlap = 0.5f, float avgTimeMs = 200.0f);
+    
+    // Reset the engine
+    void reset();
+    
+    // Feed IQ samples and get a new power spectrum if available
+    bool feedSamples(const std::complex<float>* samples, int count);
+    
+    // Process samples in buffer and generate power spectrum
+    bool process();
+    
+    // Get current power spectrum frame (dB)
+    const std::vector<float>& getPowerSpectrum() const;
+    
+    // Get access to the latest power spectrum with mutex protection
+    const float* acquireLatestPSD(int& width);
+    void releaseLatestPSD();
+    
+    // Sub-bin interpolation for accurate peak detection
+    static double refineFrequencyHz(const std::vector<float>& PdB, int binIndex, double binWidthHz);
+    
+    // Parameter getters and setters
+    int getFftSize() const { return m_fftSize; }
+    void setFftSize(int size);
+    
+    float getOverlap() const { return m_overlap; }
+    void setOverlap(float overlap);
+    
+    WindowType getWindow() const { return m_windowType; }
+    void setWindow(WindowType type);
+    
+    float getAverageTimeMs() const { return m_avgTimeMs; }
+    void setAverageTimeMs(float ms);
+    
+    int getSampleRate() const { return m_sampleRate; }
+    void setSampleRate(int rate);
+    
+    double getBinWidthHz() const;
+    
+private:
+    // FFT and processing parameters
+    int m_fftSize = 524288;    // Default to 524288 (matching the optimal size)
+    int m_sampleRate = 0;
+    float m_overlap = 0.5f;    // Default 50% overlap
+    WindowType m_windowType = WindowType::BLACKMAN_HARRIS_7;
+    float m_avgTimeMs = 200.0f;
+    
+    // Derived parameters
+    int m_hopSize = 0;         // Hop size between FFTs (derived from overlap)
+    
+    // EMA smoothing parameter
+    double m_alpha = 0.0;      // Calculated from avgTimeMs
+    
+    // FFT engine
+    fftwf_plan m_fftwPlan;
+    fftwf_complex* m_fftwIn;
+    fftwf_complex* m_fftwOut;
+    
+    // Buffers
+    std::vector<std::complex<float>> m_fftIn;
+    std::vector<std::complex<float>> m_fftOut;
+    std::vector<float> m_window;
+    std::vector<float> m_powerSpectrum;     // Power in dB
+    std::vector<float> m_avgPowerSpectrum;  // Time-averaged power in dB
+    
+    // Input sample buffer
+    std::vector<std::complex<float>> m_sampleBuffer;
+    int m_bufferOffset = 0;
+    
+    // Multi-threading protection
+    mutable std::mutex m_mutex;
+    
+    // State tracking
+    bool m_initialized = false;
+    std::atomic<bool> m_processing{false};
+    
+    // Generate window function
+    void generateWindow();
+    
+    // Calculate smoothing alpha from time constant
+    void calculateAlpha();
+};
+
+} // namespace scanner
+

--- a/misc_modules/scanner/src/scanner_README.md
+++ b/misc_modules/scanner/src/scanner_README.md
@@ -1,0 +1,42 @@
+# Scanner Module with Dedicated FFT Processing
+
+## Overview
+
+The Scanner module now includes a dedicated FFT processing engine that makes signal detection accuracy independent from the visual waterfall FFT size. This feature ensures consistent scanner performance regardless of the UI FFT settings.
+
+## Key Features
+
+- **FFT Size Independence**: Scanner detection accuracy is no longer tied to the visual FFT size
+- **CFAR Detection**: Uses Constant False Alarm Rate detection for better signal detection in varying noise conditions
+- **Sub-bin Interpolation**: Provides frequency accuracy beyond the FFT bin resolution using parabolic interpolation
+- **Hz/Time Units**: All detection parameters are expressed in Hz and milliseconds, not bins or frames
+- **Configurable Parameters**: Full control over FFT size, window function, overlap, averaging time, and detection thresholds
+
+## Settings
+
+### FFT Processing
+
+- **Use Dedicated FFT**: Enable/disable the dedicated FFT engine (enabled by default)
+- **FFT Size**: Select from 16K to 1048K points (default: 524K for optimal accuracy)
+- **Window Function**: Choose from Rectangular, Blackman, Blackman-Harris 7, Hamming, or Hann
+- **Overlap %**: Set the overlap percentage between consecutive FFT frames (default: 50%)
+- **Averaging (ms)**: Time constant for spectrum averaging (default: 200ms)
+
+### CFAR Detection
+
+- **Threshold (dB)**: Signal detection threshold above local noise floor (default: 8dB)
+- **Guard Band (Hz)**: Width of guard band around signal (default: 2000Hz)
+- **Reference (Hz)**: Width of reference band for noise floor calculation (default: 15000Hz)
+- **Min Width (Hz)**: Minimum width of a valid signal (default: 8000Hz)
+- **Merge Width (Hz)**: Distance to merge adjacent signals (default: 2000Hz)
+
+## Technical Implementation
+
+The dedicated FFT engine operates independently from the visual waterfall FFT:
+1. It taps directly into the IQ stream from the SDR source
+2. Processes IQ samples with configurable FFT parameters
+3. Applies time-domain averaging using an Exponential Moving Average (EMA)
+4. Uses CFAR detection with local noise floor estimation
+5. Refines peak frequency using parabolic interpolation for sub-bin accuracy
+
+This implementation ensures consistent scanner performance regardless of visual FFT settings, providing the best possible signal detection accuracy.

--- a/misc_modules/scanner/src/scanner_log.h
+++ b/misc_modules/scanner/src/scanner_log.h
@@ -26,3 +26,4 @@ struct Throttle {
         return false;
     }
 };
+


### PR DESCRIPTION
This commit adds a dedicated FFT pipeline for the scanner module to make its accuracy independent of the visual FFT size. Key improvements:

- Added ScannerPSD class for dedicated FFT processing
- Converted all detection parameters to Hz/ms units instead of bins/frames
- Implemented CFAR-style local thresholding for better detection
- Added sub-bin peak refinement using parabolic interpolation
- Added time-domain averaging with configurable time constant
- Updated UI to expose new FFT and detection parameters
- Added scanner_README.md with documentation

Default scanner precision now matches the "524,288-pt feel" regardless of UI FFT size and waterfall frame rate.
