### PR TITLE
further scanner optimizations

### DIFF
--- a/make_macos_bundle.sh
+++ b/make_macos_bundle.sh
@@ -48,6 +48,7 @@ bundle_install_binary $BUNDLE $BUNDLE/Contents/Plugins $BUILD_DIR/source_modules
 bundle_install_binary $BUNDLE $BUNDLE/Contents/Plugins $BUILD_DIR/source_modules/sdrpp_server_source/sdrpp_server_source.dylib
 bundle_install_binary $BUNDLE $BUNDLE/Contents/Plugins $BUILD_DIR/source_modules/spectran_http_source/spectran_http_source.dylib
 bundle_install_binary $BUNDLE $BUNDLE/Contents/Plugins $BUILD_DIR/source_modules/spyserver_source/spyserver_source.dylib
+bundle_install_binary $BUNDLE $BUNDLE/Contents/Plugins $BUILD_DIR/source_modules/soapy_source/soapy_source.dylib
 # bundle_install_binary $BUNDLE $BUNDLE/Contents/Plugins $BUILD_DIR/source_modules/usrp_source/usrp_source.dylib
 
 # Sink modules
@@ -59,7 +60,7 @@ bundle_install_binary $BUNDLE $BUNDLE/Contents/Plugins $BUILD_DIR/sink_modules/n
 bundle_install_binary $BUNDLE $BUNDLE/Contents/Plugins $BUILD_DIR/decoder_modules/meteor_demodulator/meteor_demodulator.dylib
 bundle_install_binary $BUNDLE $BUNDLE/Contents/Plugins $BUILD_DIR/decoder_modules/pager_decoder/pager_decoder.dylib
 bundle_install_binary $BUNDLE $BUNDLE/Contents/Plugins $BUILD_DIR/decoder_modules/radio/radio.dylib
-
+#bundle_install_binary $BUNDLE $BUNDLE/Contents/Plugins $BUILD_DIR/decoder_modules/tetra_decoder/tetra_decoder.dylib
 # Misc modules
 bundle_install_binary $BUNDLE $BUNDLE/Contents/Plugins $BUILD_DIR/misc_modules/discord_integration/discord_integration.dylib
 bundle_install_binary $BUNDLE $BUNDLE/Contents/Plugins $BUILD_DIR/misc_modules/frequency_manager/frequency_manager.dylib


### PR DESCRIPTION
### Summary

This PR improves the Scanner module’s tuning behavior and enforces safe, predictable scan boundaries. It also updates the macOS app bundle to include the SoapySDR source by default so users can plug in Soapy-compatible devices without extra setup. 
[GitHub](https://github.com/LunaeMons/SDRPlusPlus_CommunityEdition/pull/44/commits/625f85805aaef0becc7b35f2911583508c6e5847)

### What’s changed

Continuous tuning self-centering: When the scanner locks a signal, the tuner now recenters itself more reliably to stay on-peak instead of drifting toward the edge. 
[GitHub](https://github.com/LunaeMons/SDRPlusPlus_CommunityEdition/pull/44/commits/625f85805aaef0becc7b35f2911583508c6e5847)

Per-entry/band boundaries enforced: Scanning is now restricted to the active Frequency Manager scope (the current band or single-frequency entry). This prevents the scanner from stepping outside the user’s defined ranges. 
[GitHub](https://github.com/LunaeMons/SDRPlusPlus_CommunityEdition/pull/44/commits/625f85805aaef0becc7b35f2911583508c6e5847)

macOS bundle improvement: SoapySDR source is included by default in the .app bundle, enabling out-of-the-box support for Soapy devices on macOS. (See make_macos_bundle.sh change.) 
[GitHub](https://github.com/LunaeMons/SDRPlusPlus_CommunityEdition/pull/44/files)

### Why

Keeps the tuner centered on the actual signal during “lock,” improving decode stability and UX.

Avoids unwanted hops outside user-defined bands/entries, making scanning safer and more deterministic for band-limited sweeps or curated frequency lists.

### Regression risk

Low. Changes are localized to the scanner’s tuning/limit logic and macOS bundling script.