### PR TITLE
Scanner: Add Visual Trigger Level Indicator on FFT Display

### DIFF
--- a/SCANNER_TRIGGER_LEVEL_FEATURE.md
+++ b/SCANNER_TRIGGER_LEVEL_FEATURE.md
@@ -1,0 +1,165 @@
+# Scanner Trigger Level Visualization Feature
+
+## Overview
+This feature adds a visual indicator for the scanner trigger level on the FFT display, making it easier for users to understand and adjust their scanning threshold.
+
+## Implementation Details
+
+### 1. Core Components Added
+
+#### FFT Redraw Handler
+- Added `EventHandler<ImGui::WaterFall::FFTRedrawArgs> fftRedrawHandler` to scanner module
+- Registered with `gui::waterfall.onFFTRedraw.bindHandler(&fftRedrawHandler)` in constructor
+- Properly unbound in destructor for clean shutdown
+
+#### Trigger Level Line Drawing
+- Horizontal orange line drawn across the entire FFT display width
+- Line position calculated based on trigger level value in dBFS
+- Automatic scaling with FFT display range (fftMin to fftMax)
+- Line thickness scales with UI scale factor for consistency
+
+#### Text Label
+- Shows trigger level value (e.g., "-50.0 dBFS") next to the line
+- Positioned at right edge of FFT display
+- Semi-transparent black background for better visibility
+- Orange text color matching the line
+
+### 2. Configuration Integration
+
+#### New Configuration Option
+- Added `showTriggerLevel` boolean setting (default: true)
+- Persisted in scanner configuration file
+- Loaded/saved with other scanner settings
+
+#### User Interface Control
+- Added "Show Trigger Level" checkbox in scanner menu
+- Tooltip explains the feature purpose and benefits
+- Immediate save when toggled
+
+### 3. Visual Design
+
+#### Color Scheme
+- **Line Color**: Orange (`IM_COL32(255, 165, 0, 200)`) with transparency
+- **Text Color**: Solid orange (`IM_COL32(255, 165, 0, 255)`)
+- **Background**: Semi-transparent black (`IM_COL32(0, 0, 0, 128)`)
+
+#### Positioning Logic
+```cpp
+// Calculate Y position (FFT display is inverted, max at top)
+float scaleFactor = (args.max.y - args.min.y) / vertRange;
+float yPos = args.max.y - ((clampedLevel - fftMin) * scaleFactor);
+```
+
+#### Responsive Behavior
+- Line position updates in real-time as trigger level changes
+- Automatically clamps to visible FFT range
+- Scales properly with different FFT zoom levels
+- Works with all FFT display modes
+
+### 4. Code Changes Summary
+
+#### Files Modified
+- `misc_modules/scanner/src/main.cpp` - Main implementation
+
+#### Key Functions Added
+- `static void fftRedraw(ImGui::WaterFall::FFTRedrawArgs args, void* ctx)` - Main drawing function
+
+#### Configuration Keys Added
+- `showTriggerLevel` (boolean, default: true)
+
+#### UI Elements Added
+- "Show Trigger Level" checkbox with tooltip
+
+### 5. Benefits for Users
+
+#### Improved Usability
+- Visual feedback for trigger level setting
+- Easier to understand relationship between signals and threshold
+- Helps optimize scanning sensitivity
+
+#### Better Signal Analysis
+- Clear indication of detection threshold
+- Assists in avoiding false triggers
+- Helps identify optimal trigger levels for different bands
+
+#### Enhanced Workflow
+- No need to guess trigger level effectiveness
+- Visual confirmation of scanner configuration
+- Immediate feedback when adjusting settings
+
+### 6. Technical Implementation Notes
+
+#### Performance Considerations
+- Drawing only occurs when `showTriggerLevel` is enabled
+- Minimal computational overhead (simple line drawing)
+- Uses existing ImGui drawing infrastructure
+- No impact on DSP performance
+
+#### Thread Safety
+- FFT redraw handler runs on UI thread
+- No interaction with DSP threads
+- Safe access to configuration variables
+
+#### Memory Management
+- No dynamic memory allocation in drawing code
+- Uses stack-allocated variables for calculations
+- Proper cleanup in destructor
+
+### 7. Testing and Validation
+
+#### Functionality Tests
+- ✅ Line appears when feature is enabled
+- ✅ Line disappears when feature is disabled
+- ✅ Line position updates with trigger level changes
+- ✅ Text label shows correct dBFS value
+- ✅ Configuration persists across app restarts
+
+#### Visual Tests
+- ✅ Line is clearly visible against FFT background
+- ✅ Text is readable with background contrast
+- ✅ Colors are consistent with design
+- ✅ Scaling works properly at different UI scales
+
+#### Integration Tests
+- ✅ No interference with existing scanner functionality
+- ✅ Compatible with all scanner modes
+- ✅ Works with frequency manager integration
+- ✅ No impact on scanning performance
+
+### 8. Usage Instructions
+
+#### Enabling the Feature
+1. Open SDR++ and navigate to the Scanner module
+2. Locate the "Show Trigger Level" checkbox
+3. Check the box to enable the visualization (enabled by default)
+
+#### Using the Feature
+1. Adjust the "Trigger Level" slider in the scanner
+2. Observe the orange horizontal line on the FFT display
+3. The line shows exactly where your trigger threshold is set
+4. Signals above the line will trigger the scanner
+5. Use this visual guide to optimize your trigger level
+
+#### Tips for Best Results
+- Set trigger level just above the noise floor
+- Use the visual line to avoid setting it too high (missing weak signals)
+- Adjust based on band conditions and desired sensitivity
+- The line helps identify when signals are strong enough to trigger
+
+### 9. Future Enhancements (Potential)
+
+#### Additional Visual Elements
+- Color-coded zones (noise floor, signal area, etc.)
+- Multiple threshold lines for different scanning modes
+- Signal strength indicators relative to trigger level
+
+#### Advanced Features
+- Automatic trigger level adjustment based on noise floor
+- Historical trigger level effectiveness display
+- Band-specific trigger level recommendations
+
+### 10. Conclusion
+
+This feature significantly improves the user experience of the scanner module by providing clear visual feedback about the trigger level setting. It makes the scanner more intuitive to use and helps users optimize their scanning configuration for better results.
+
+The implementation follows SDR++ architectural patterns, maintains performance, and integrates seamlessly with existing functionality while providing substantial value to users.

--- a/misc_modules/scanner/src/main.cpp
+++ b/misc_modules/scanner/src/main.cpp
@@ -130,8 +130,15 @@ public:
         
         flog::info("Scanner: Initializing scanner module '{}'", name);
         
+        // Set up FFT redraw handler for trigger level visualization
+        fftRedrawHandler.ctx = this;
+        fftRedrawHandler.handler = fftRedraw;
+        
         gui::menu.registerEntry(name, menuHandler, this, NULL);
         loadConfig();
+        
+        // Bind FFT redraw handler for trigger level line
+        gui::waterfall.onFFTRedraw.bindHandler(&fftRedrawHandler);
         
         // Check for midnight reset on module initialization
         checkMidnightReset();
@@ -144,6 +151,9 @@ public:
 
     ~ScannerModule() {
         flog::info("Scanner: Destructor called, cleaning up");
+        
+        // Unbind FFT redraw handler
+        gui::waterfall.onFFTRedraw.unbindHandler(&fftRedrawHandler);
         
         // Stop scanner and set running to false
         running = false;
@@ -957,6 +967,16 @@ private:
         if (ImGui::Checkbox(("##scanner_show_signal_info_" + _this->name).c_str(), &_this->showSignalInfo)) {
             _this->saveConfig();
         }
+        
+        ImGui::LeftLabel("Show Trigger Level");
+        if (ImGui::IsItemHovered()) {
+            ImGui::SetTooltip("Show horizontal line on FFT display indicating trigger level\n"
+                             "Visual indicator shows where scanner threshold is set\n"
+                             "Helps with adjusting trigger level for optimal scanning");
+        }
+        if (ImGui::Checkbox(("##scanner_show_trigger_level_" + _this->name).c_str(), &_this->showTriggerLevel)) {
+            _this->saveConfig();
+        }
 
         // Blacklist controls
         ImGui::Separator();
@@ -1651,6 +1671,7 @@ private:
         config.conf["showSignalTooltip"] = showSignalTooltip;
         config.conf["unlockHighSpeed"] = unlockHighSpeed;
         config.conf["tuningTimeAuto"] = tuningTimeAuto;
+        config.conf["showTriggerLevel"] = showTriggerLevel;
         
         // Save frequency ranges
         json rangesArray = json::array();
@@ -1707,6 +1728,7 @@ private:
         showSignalTooltip = config.conf.value("showSignalTooltip", false);
         unlockHighSpeed = config.conf.value("unlockHighSpeed", false);
         tuningTimeAuto = config.conf.value("tuningTimeAuto", false);
+        showTriggerLevel = config.conf.value("showTriggerLevel", true);
         
         // Initialize time points
         lastNoiseUpdate = std::chrono::high_resolution_clock::now();
@@ -3847,6 +3869,10 @@ private:
     bool showSignalTooltip = false;         // Whether to show persistent signal tooltip
     std::chrono::time_point<std::chrono::high_resolution_clock> lastSignalAnalysisTime; // Time of last signal analysis update
     
+    // Trigger level visualization settings
+    bool showTriggerLevel = true;            // Show horizontal line for trigger level on FFT display
+    EventHandler<ImGui::WaterFall::FFTRedrawArgs> fftRedrawHandler;
+    
     // Continuous signal centering
     std::chrono::time_point<std::chrono::high_resolution_clock> lastCenteringTime; // Time of last signal centering
     const int CENTERING_INTERVAL_MS = 50; // Interval for continuous centering in milliseconds
@@ -4108,6 +4134,52 @@ private:
         return "Unknown";
     }
     
+    // FFT redraw handler for trigger level visualization
+    static void fftRedraw(ImGui::WaterFall::FFTRedrawArgs args, void* ctx) {
+        ScannerModule* _this = (ScannerModule*)ctx;
+        
+        // Only draw if trigger level visualization is enabled
+        if (!_this->showTriggerLevel) { return; }
+        
+        // Calculate the Y position of the trigger level line
+        // Convert trigger level (dBFS) to pixel position on FFT display
+        float fftMin = gui::waterfall.getFFTMin();
+        float fftMax = gui::waterfall.getFFTMax();
+        float vertRange = fftMax - fftMin;
+        
+        // Clamp trigger level to visible range
+        float clampedLevel = std::clamp(_this->level, fftMin, fftMax);
+        
+        // Calculate Y position (note: FFT display is inverted, max is at top)
+        float scaleFactor = (args.max.y - args.min.y) / vertRange;
+        float yPos = args.max.y - ((clampedLevel - fftMin) * scaleFactor);
+        
+        // Draw horizontal line across the entire FFT width
+        ImU32 lineColor = IM_COL32(255, 165, 0, 200); // Orange color with transparency
+        args.window->DrawList->AddLine(
+            ImVec2(args.min.x, yPos), 
+            ImVec2(args.max.x, yPos), 
+            lineColor, 
+            2.0f * style::uiScale  // Line thickness scaled with UI
+        );
+        
+        // Optional: Add text label showing the trigger level value
+        char levelText[32];
+        snprintf(levelText, sizeof(levelText), "%.1f dBFS", _this->level);
+        ImVec2 textSize = ImGui::CalcTextSize(levelText);
+        
+        // Position text at right edge of FFT display
+        ImVec2 textPos = ImVec2(args.max.x - textSize.x - 5, yPos - textSize.y - 2);
+        
+        // Draw text background for better visibility
+        ImVec2 bgMin = ImVec2(textPos.x - 2, textPos.y - 1);
+        ImVec2 bgMax = ImVec2(textPos.x + textSize.x + 2, textPos.y + textSize.y + 1);
+        args.window->DrawList->AddRectFilled(bgMin, bgMax, IM_COL32(0, 0, 0, 128));
+        
+        // Draw the text
+        args.window->DrawList->AddText(textPos, IM_COL32(255, 165, 0, 255), levelText);
+    }
+    
     // Module interface handler for external communication
     static void scannerInterfaceHandler(int code, void* in, void* out, void* ctx) {
         ScannerModule* _this = (ScannerModule*)ctx;
@@ -4227,6 +4299,7 @@ MOD_EXPORT void _INIT_() {
         def["showSignalTooltip"] = false;
         def["unlockHighSpeed"] = false;
         def["tuningTimeAuto"] = false;
+        def["showTriggerLevel"] = true;
     
     // Scanning direction preference 
     def["scanUp"] = true; // Default to increasing frequency


### PR DESCRIPTION
## Overview
This PR adds a visual indicator for the scanner trigger level on the FFT display, making it easier for users to understand and adjust their scanning threshold.

## Features Added
- **Visual Trigger Level Line**: Horizontal orange line across FFT display showing exact trigger level position
- **Real-time Updates**: Line position updates dynamically as trigger level slider changes  
- **dBFS Text Label**: Shows precise trigger level value next to the line
- **Toggle Control**: 'Show Trigger Level' checkbox in scanner UI (enabled by default)
- **Automatic Scaling**: Works with all FFT zoom levels and display ranges
- **Performance Optimized**: Only draws when enabled, minimal overhead

## Benefits
- **Improved Usability**: Visual feedback for trigger threshold setting
- **Better Signal Analysis**: Clear indication of detection threshold relative to signals
- **Enhanced Workflow**: Helps optimize scanning sensitivity and avoid false triggers
- **User-Friendly**: No guessing - see exactly where your trigger level is set

## Technical Implementation
- Added FFT redraw event handler to scanner module
- Integrated with existing waterfall drawing system  
- Follows SDR++ architectural patterns
- Thread-safe with proper cleanup
- Configurable and persistent settings

## Testing
- ✅ Line appears/disappears with toggle control
- ✅ Position updates with trigger level changes
- ✅ Text label shows correct dBFS values
- ✅ Works across different FFT zoom levels
- ✅ No impact on scanner performance
- ✅ Configuration persists across sessions

## Screenshots
The orange horizontal line clearly shows the trigger level position on the FFT display, with the dBFS value labeled for precision.

## Usage
1. Open Scanner module
2. Enable 'Show Trigger Level' checkbox (default: on)
3. Adjust trigger level slider and observe the orange line
4. Use visual guide to optimize trigger sensitivity

This feature significantly improves the scanner user experience by providing the visual feedback that was previously missing.